### PR TITLE
Run 'gofmt -w -s' on sources

### DIFF
--- a/colwriter/column_test.go
+++ b/colwriter/column_test.go
@@ -36,7 +36,7 @@ version.go
 windows.go
 `[1:]
 
-var tests = []struct{
+var tests = []struct {
 	wid  int
 	flag uint
 	src  string

--- a/wrap.go
+++ b/wrap.go
@@ -31,7 +31,7 @@ func WrapBytes(b []byte, lim int) []byte {
 
 // WrapWords is the low-level line-breaking algorithm, useful if you need more
 // control over the details of the text wrapping process. For most uses, either
-// Wrap or WrapBytes will be sufficient and more convenient. 
+// Wrap or WrapBytes will be sufficient and more convenient.
 //
 // WrapWords splits a list of words into lines with minimal "raggedness",
 // treating each byte as one unit, accounting for spc units between adjacent


### PR DESCRIPTION
When using 'gofmt -w -s .' in a directory that is godeps'ed, it causes the following change, which is slightly annoying.
