### PR TITLE
Fix formatting of adjacent long words.

### DIFF
--- a/wrap.go
+++ b/wrap.go
@@ -65,7 +65,7 @@ func WrapWords(words [][]byte, spc, lim, pen int) [][][]byte {
 			for j := i + 1; j < n; j++ {
 				d := lim - length[i][j-1]
 				c := d*d + cost[j]
-				if length[i][j-1] > lim {
+				if length[i][j-1] > lim && i != (j-1) {
 					c += pen // too-long lines get a worse penalty
 				}
 				if c < cost[i] {

--- a/wrap_test.go
+++ b/wrap_test.go
@@ -51,6 +51,7 @@ func TestWrapBug1(t *testing.T) {
 	}{
 		{4, "aaaaa", "aaaaa"},
 		{4, "a aaaaa", "a\naaaaa"},
+		{4, "overlong overlong foo", "overlong\noverlong\nfoo"},
 	}
 
 	for _, test := range cases {


### PR DESCRIPTION
If two words that are exceeding the line length follow each other, the algorithm previously pulled them on a single line because this way the penalty was paid only once.

This patch fixes this behavior by not adding the penalty if the line is exceeded due to a long word, i.e. when it is unavoidable.

CC: @diekmann